### PR TITLE
feat: persist chat history and track requests

### DIFF
--- a/Applications/Chat/ChatDb.php
+++ b/Applications/Chat/ChatDb.php
@@ -1,0 +1,54 @@
+<?php
+class ChatDb
+{
+    private static ?\PDO $db = null;
+
+    private static function init(): void
+    {
+        if (self::$db !== null) {
+            return;
+        }
+        $file = __DIR__ . '/chat.sqlite';
+        self::$db = new \PDO('sqlite:' . $file);
+        self::$db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        self::$db->exec('CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            room_id TEXT,
+            from_id TEXT,
+            from_name TEXT,
+            to_id TEXT,
+            content TEXT,
+            time TEXT
+        )');
+        self::$db->exec('CREATE TABLE IF NOT EXISTS requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT,
+            user_agent TEXT,
+            ip TEXT,
+            time TEXT
+        )');
+    }
+
+    public static function logMessage(string $room, string $from_id, string $from_name, string $to_id, string $content): void
+    {
+        self::init();
+        $stmt = self::$db->prepare('INSERT INTO messages (room_id, from_id, from_name, to_id, content, time) VALUES (?,?,?,?,?,?)');
+        $stmt->execute([$room, $from_id, $from_name, $to_id, $content, date('Y-m-d H:i:s')]);
+    }
+
+    public static function getMessages(string $room, int $limit = 50): array
+    {
+        self::init();
+        $stmt = self::$db->prepare('SELECT room_id, from_id as from_client_id, from_name as from_client_name, to_id as to_client_id, content, time FROM messages WHERE room_id = ? ORDER BY id DESC LIMIT ?');
+        $stmt->execute([$room, $limit]);
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return array_reverse($rows);
+    }
+
+    public static function logRequest(string $path, string $user_agent, string $ip): void
+    {
+        self::init();
+        $stmt = self::$db->prepare('INSERT INTO requests (path, user_agent, ip, time) VALUES (?,?,?,?)');
+        $stmt->execute([$path, $user_agent, $ip, date('Y-m-d H:i:s')]);
+    }
+}

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -44,6 +44,11 @@
     .dot.ok{background:var(--ok)} .dot.busy{background:var(--busy)} .dot.away{background:var(--away)}
     .select{width:100%;background:#0b1220;border:1px solid #203244;color:#e5e7eb;padding:.45rem .5rem;border-radius:6px}
     .hint{font-size:.8rem;color:#a3b2c7}
+    @media (max-width:768px){
+      body{flex-direction:column;height:auto}
+      .sidebar{width:100%;flex-direction:row;flex-wrap:wrap;height:auto}
+      .chat{order:2}
+    }
   </style>
 </head>
 <body>
@@ -124,7 +129,7 @@ function loginRoom(roomId){
   // reset UI utilisateurs (évite l'affichage d'une ancienne liste avant le "welcome")
   clients = {};
   renderUsers();
-  ws.send(JSON.stringify({type:'login', client_name:name, room_id:roomId, status}));
+  ws.send(JSON.stringify({type:'login', client_name:name, room_id:roomId, status, ua: navigator.userAgent}));
 }
 
 function changeStatus(){
@@ -158,6 +163,11 @@ function onmessage(e){
       // S’assure que l’onglet de la room existe et devient actif
       ensureRoomTab(data.room_id);
       renderRooms();
+      break;
+    }
+    case 'history': {
+      (data.messages || []).forEach(m => storeMessage(m));
+      renderMessages();
       break;
     }
 

--- a/Applications/Chat/start_web.php
+++ b/Applications/Chat/start_web.php
@@ -7,6 +7,7 @@ use Workerman\Protocols\Http\Response;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/ChatDb.php';
 
 
 
@@ -24,6 +25,7 @@ define('WEBROOT', __DIR__ . DIRECTORY_SEPARATOR .  'Web');
 define('APIROOT', __DIR__ . DIRECTORY_SEPARATOR .  'Api');
 
 $web->onMessage = function (TcpConnection $connection, Request $request) {
+    ChatDb::logRequest($request->path(), $request->header('user-agent', ''), $connection->getRemoteIp());
     $_GET = $request->get();
     $path = $request->path();
     if ($path === '/') {


### PR DESCRIPTION
## Summary
- add SQLite database helper for chat history and request logging
- log HTTP requests and WebSocket logins for bot detection
- persist room and DM messages and deliver history on login
- update web UI for responsive layout and send user agent

## Testing
- `php -l Applications/Chat/ChatDb.php`
- `php -l Applications/Chat/Events.php`
- `php -l Applications/Chat/start_web.php`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b260f71ba0832e827f1437bb7ae7d1