### PR TITLE
Enable nickname selection and rename sync

### DIFF
--- a/Applications/Chat/Events.php
+++ b/Applications/Chat/Events.php
@@ -94,6 +94,20 @@ class Events
                 return;
             }
 
+            case 'rename': {
+                $new = htmlspecialchars(trim($data['client_name'] ?? ''));
+                if ($new === '') $new = 'Invité';
+                $_SESSION['client_name'] = $new;
+                $room_id = $_SESSION['room_id'] ?? 'general';
+                $msg = [
+                    'type'       => 'rename',
+                    'client_id'  => $client_id,
+                    'client_name'=> $new,
+                ];
+                Gateway::sendToGroup($room_id, json_encode($msg));
+                return;
+            }
+
             /**
              * Création d'une room.
              *  - publique  => "new_room" broadcast (apparait pour tout le monde)


### PR DESCRIPTION
## Summary
- allow clients to pick a nickname stored in localStorage
- add rename support with server broadcast and UI refresh

## Testing
- `php -l Applications/Chat/Events.php`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4c1030a74832e8b488f7e84f8d5f0