### PR TITLE
feat(chat): add user-friendly call error messages

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,6 +5,14 @@ $_config = [
     'ssl'      => true,
     'localdev' => true,
     'geoip'    => false,
+    // Default STUN/TURN servers used by WebRTC
+    // Additional TURN servers can be added here to ensure connectivity
+    // between peers behind restrictive NATs.
+    'ice_servers' => [
+        ['urls' => 'stun:stun.l.google.com:19302'],
+        // Example TURN configuration (replace with your own server)
+        // ['urls' => 'turn:turn.example.com:3478', 'username' => 'user', 'credential' => 'pass'],
+    ],
 ];
 
 $scheme = $_config['ssl'] ? 'wss://' : 'ws://';


### PR DESCRIPTION
## Summary
- show call errors in overlay with clear French explanations
- surface connection failures from signaling and WebRTC peers

## Testing
- `php -l config.php`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b64d5965e4832e910aef54b6f25d8f