### PR TITLE
feat: add pwa push and gps deep links

### DIFF
--- a/Applications/Chat/Web/manifest.json
+++ b/Applications/Chat/Web/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Couckan Chat",
+  "short_name": "Couckan",
+  "start_url": "./index.php",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "description": "Couckan chat application",
+  "icons": []
+}

--- a/Applications/Chat/Web/sw.js
+++ b/Applications/Chat/Web/sw.js
@@ -1,0 +1,24 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('couckan-cache-v1').then(cache => cache.addAll([
+      './',
+      './index.php'
+    ]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});
+
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Notification';
+  const options = {
+    body: data.body || '',
+    icon: data.icon || ''
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});


### PR DESCRIPTION
## Summary
- register service worker and manifest for PWA with push support
- add toolbar control for push subscription
- allow deep links to start location tracking or prompt GPS activation

## Testing
- `php -l Applications/Chat/Web/index.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b675139474832eb44dcd7d64014bec