### PR TITLE
feat: expose chat overlay with blurred transparency

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -650,6 +650,7 @@ let rooms = new Map([['general', {visibility:'public', creator_id:null}]]);
 
 // rejoindre via lien ?room=xxx
 const q = new URLSearchParams(location.search);
+const initialRoom = q.get('room') || 'general';
 if (q.get('room')) rooms.set(q.get('room'), {visibility:'private', creator_id:null});
 
 function addOrUpdateLocation(loc){
@@ -754,7 +755,7 @@ function connect(){
   ws.onopen = () => {
     if (!name) name = localStorage.getItem('chatName') || 'Invité';
     // login première room : soit "general", soit celle de l'URL si présente
-    loginRoom([...rooms.keys()][0]);
+    loginRoom(initialRoom);
     if (navigator.permissions && navigator.permissions.query) {
       navigator.permissions.query({name:'geolocation'}).then(res => {
         if (res.state === 'granted' && locationState !== 'none') shareLocation();
@@ -1220,7 +1221,9 @@ function openDM(id, username){
   tabs[key] = 'DM avec ' + username;
   currentKey = key;
   chatWrapper.classList.add('active');
+  document.querySelectorAll('.sidebar').forEach(s => s.classList.remove('open','collapsed'));
   renderTabs();
+  clearBlink(key);
   renderMessages();
   chatBtn.classList.remove('blink');
 }

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -641,9 +641,6 @@ let currentKey = 'room_general';
 let messages   = { room_general: [] };
 let tabs       = { room_general: 'Salle générale' };
 let notificationsAllowed = (typeof Notification !== 'undefined' && Notification.permission === 'granted');
-if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') {
-  Notification.requestPermission().then(p => { notificationsAllowed = (p === 'granted'); });
-}
 
 // liste d’utilisateurs de la room active : { id: {name, status} }
 
@@ -707,7 +704,11 @@ function shareLocation(){
   };
 
   const errorHandler = err => {
-    console.warn('Erreur de localisation :', err.message);
+    const msg = (err && err.message) ? err.message : 'permission refusée';
+    console.warn('Erreur de localisation :', msg);
+    locationState = 'none';
+    updateLocBtn();
+    stopLocation();
   };
 
   // iOS Safari requires getCurrentPosition to be called directly from a user gesture


### PR DESCRIPTION
## Summary
- lighten overlay palette so chat and sidebars use softer transparency
- add blur and reduced height to chat elements to keep globe visible while messaging
- surface login/logout events as interactive notifications that blink chat and offer quick DM access
- allow rooms and users panes to collapse on desktop while remaining mobile-friendly

## Testing
- `php -l Applications/Chat/Web/index.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6d5a440832e85644a1ae0a63900