### PR TITLE
Start geolocation watch immediately

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -699,8 +699,9 @@ function shareLocation(){
   // iOS Safari requires getCurrentPosition to be called directly from a user gesture
   navigator.geolocation.getCurrentPosition(pos => {
     sendPosition(pos);
-    locationWatchId = navigator.geolocation.watchPosition(sendPosition, errorHandler, options);
   }, errorHandler, options);
+
+  locationWatchId = navigator.geolocation.watchPosition(sendPosition, errorHandler, options);
 }
 
 function stopLocation(){


### PR DESCRIPTION
## Summary
- Start geolocation watch immediately after requesting current position
- Send initial location once and keep existing error handling

## Testing
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b765160394832ebfecff6ea0bedcec