### PR TITLE
Delay notification permission request until bell click

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -177,7 +177,8 @@ function getUserMedia(constraints){
 const storedId = localStorage.getItem('chatUid');
 let ws, name, client_id = storedId, status = 'online', clients = {};
 let locationWatchId = null, hasFlownToLocation = false;
-let notifState = 'all', locationState = 'none';
+let notifState = (typeof Notification !== 'undefined' && Notification.permission === 'granted') ? 'all' : 'none',
+    locationState = 'none';
 const mutedUsers = new Set();
 let signal, callRoom = null, peers = {}, localStream = null, callVideo = false;
 let lastCallRoom = null, lastCallVideo = false;


### PR DESCRIPTION
## Summary
- Start with notifications disabled unless browser permission is already granted
- Request notification permission only after the user clicks the bell

## Testing
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7788c17ac832e8556752cbcd5d837