### PR TITLE
feat: handle real user locations

### DIFF
--- a/Applications/Chat/Events.php
+++ b/Applications/Chat/Events.php
@@ -86,14 +86,16 @@ class Events
                 $randLon = mt_rand(-50, 50) / 1000;
 
                 // stocke la position dans la session pour la partager entre les workers
-                $_SESSION['lat'] = $randLat;
-                $_SESSION['lon'] = $randLon;
+                $_SESSION['lat']  = $randLat;
+                $_SESSION['lon']  = $randLon;
+                $_SESSION['real'] = false; // localisation par défaut proche de Null Island
 
                 self::$locations[$client_uuid] = [
                     'client_id'   => $client_uuid,
                     'client_name' => $client_name,
                     'lat'         => $randLat,
                     'lon'         => $randLon,
+                    'real'        => false,
                 ];
                 $loc = self::$locations[$client_uuid];
                 $loc['type'] = 'location';
@@ -112,6 +114,7 @@ class Events
                         'client_name' => $sess['client_name'] ?? 'Invité',
                         'lat'         => $sess['lat'],
                         'lon'         => $sess['lon'],
+                        'real'        => $sess['real'] ?? false,
                     ];
                 }
 
@@ -173,9 +176,11 @@ class Events
                     'client_name' => $client_name,
                     'lat'         => (float)$lat,
                     'lon'         => (float)$lon,
+                    'real'        => true,
                 ];
-                $_SESSION['lat'] = (float)$lat;
-                $_SESSION['lon'] = (float)$lon;
+                $_SESSION['lat']  = (float)$lat;
+                $_SESSION['lon']  = (float)$lon;
+                $_SESSION['real'] = true;
                 $msg = self::$locations[$uuid];
                 $msg['type'] = 'location';
                 Gateway::sendToAll(json_encode($msg));
@@ -187,6 +192,7 @@ class Events
                 if (isset(self::$locations[$uuid])) {
                     unset(self::$locations[$uuid]);
                     unset($_SESSION['lat'], $_SESSION['lon']);
+                    $_SESSION['real'] = false;
                     Gateway::sendToAll(json_encode(['type'=>'location_remove','client_id'=>$uuid]));
                 }
                 return;

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -320,7 +320,14 @@ viewBtn.onclick = () => {
     viewer.trackedEntity = null;
     if (locationEntities[client_id]) {
       const pos = locationEntities[client_id].position.getValue(Cesium.JulianDate.now());
-      viewer.camera.flyTo({destination: pos});
+      const carto = Cesium.Cartographic.fromCartesian(pos);
+      viewer.camera.flyTo({
+        destination: Cesium.Cartesian3.fromRadians(
+          carto.longitude,
+          carto.latitude,
+          5000
+        )
+      });
     }
   }
   updateViewBtn();

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -671,7 +671,7 @@ function addOrUpdateLocation(loc){
   let ent = locationEntities[id];
   const st = (clients[id] && clients[id].status) || 'online';
   const col = statusColors[st] || Cesium.Color.CYAN;
-  const wasReal = ent && ent.properties && ent.properties.real;
+  const wasReal = !!(ent && ent.properties && ent.properties.real && ent.properties.real.getValue(Cesium.JulianDate.now()));
   const isReal = !!loc.real;
   if (!clients[id]) clients[id] = {name: loc.client_name || 'Invité', status: 'online'};
   clients[id].located = isReal;

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -179,7 +179,7 @@ let ws, name, client_id = storedId, status = 'online', clients = {};
 let locationWatchId = null, hasFlownToLocation = false;
 let notifState = (typeof Notification !== 'undefined' && Notification.permission === 'granted') ? 'all' : 'none',
     locationState = 'none',
-    viewState = 'home';
+    viewState = 'new';
 const mutedUsers = new Set();
 let signal, callRoom = null, peers = {}, localStream = null, callVideo = false;
 let lastCallRoom = null, lastCallVideo = false;


### PR DESCRIPTION
## Summary
- track real vs default positions on the server
- allow clients to jump to new localized users or their own position
- display a pin beside users sharing a true location

## Testing
- `php -l Applications/Chat/Events.php`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b786c44f20832ea0992c5d092eb862