### PR TITLE
Add start overlay with watch or play options

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -361,11 +361,13 @@ toolbar.appendChild(viewBtn);
 
 const startOverlay = document.getElementById('startOverlay');
 document.getElementById('watchBtn').onclick = () => {
+  showToast('Vous allez être posé sur Null Island (0 latitude, 0 longitude)');
   startOverlay.style.display = 'none';
   viewer.trackedEntity = null;
   viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,1000000)});
 };
 document.getElementById('playBtn').onclick = () => {
+  showToast('Vous allez être posé sur la Terre');
   startOverlay.style.display = 'none';
   locationState = 'all';
   shareLocation();

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -82,6 +82,9 @@ include __DIR__ . '/../../../config.php';
     #callOverlay .error{color:#f87171;margin-top:.5rem;text-align:center}
     #remoteVideos{display:flex;flex-wrap:wrap;justify-content:center}
     #callControls{display:flex;gap:.5rem;flex-wrap:wrap;justify-content:center;margin-top:.5rem}
+    #startOverlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;align-items:center;justify-content:center;gap:2rem;background:rgba(0,0,0,.5);z-index:200}
+    #startOverlay .choice{background:var(--panel);color:var(--text);padding:2rem 3rem;border-radius:12px;text-align:center;font-size:1.5rem;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:.5rem}
+    #startOverlay .choice span{font-size:2.5rem}
     @media (max-width:768px){
       #chatWrapper{width:95%;right:2.5%;max-height:60vh}
       .sidebar{position:absolute;top:0;bottom:0;flex:none;width:80%;max-width:320px;background:var(--panel);height:100%;overflow-y:auto;transform:translateX(-100%);transition:transform .3s;z-index:20}
@@ -94,6 +97,10 @@ include __DIR__ . '/../../../config.php';
 </head>
 <body>
   <div id="cesiumContainer"></div>
+  <div id="startOverlay">
+    <div class="choice" id="watchBtn"><span>👁️</span>Regarder</div>
+    <div class="choice" id="playBtn"><span>📍</span>Jouer</div>
+  </div>
   <div id="chatWrapper">
   <!-- Chat -->
   <main class="chat">
@@ -346,6 +353,19 @@ viewBtn.onclick = () => {
   updateViewBtn();
 };
 toolbar.appendChild(viewBtn);
+
+const startOverlay = document.getElementById('startOverlay');
+document.getElementById('watchBtn').onclick = () => {
+  startOverlay.style.display = 'none';
+  viewer.trackedEntity = null;
+  viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,1000000)});
+};
+document.getElementById('playBtn').onclick = () => {
+  startOverlay.style.display = 'none';
+  locationState = 'all';
+  shareLocation();
+  updateLocBtn();
+};
 const homeBtn = toolbar.querySelector('.cesium-home-button');
 if (homeBtn) {
   homeBtn.addEventListener('click', () => {

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -234,6 +234,7 @@ const statusColors = {
 const chatWrapper = document.getElementById('chatWrapper');
 const toolbar = document.querySelector('.cesium-viewer-toolbar');
 const profilePopup = document.getElementById('profilePopup');
+let justOpenedProfile = false;
 const usersPanel = document.getElementById('usersPanel');
 const toastContainer = document.getElementById('toastContainer');
 const chatToggle = document.getElementById('chatToggle');
@@ -336,6 +337,7 @@ viewBtn.onclick = () => {
   if (viewState === 'home') {
     viewer.trackedEntity = null;
     viewer.camera.flyHome(1);
+    showToast('Vue initiale');
   } else if (viewState === 'me') {
     viewer.trackedEntity = null;
     if (locationEntities[client_id]) {
@@ -349,6 +351,9 @@ viewBtn.onclick = () => {
         )
       });
     }
+    showToast('Voler vers ma position');
+  } else {
+    showToast('Voler vers les nouveaux utilisateurs localisés');
   }
   updateViewBtn();
 };
@@ -374,6 +379,7 @@ if (homeBtn) {
 }
 
 document.addEventListener('click', (e) => {
+  if (justOpenedProfile) { justOpenedProfile = false; return; }
   const path = e.composedPath();
   const insideChat = path.includes(chatWrapper);
   const onToggle = path.includes(chatToggle);
@@ -404,6 +410,7 @@ handler.setInputAction(function(click){
 }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
 function showProfilePopup(id, uname, position){
+  justOpenedProfile = true;
   profilePopup.innerHTML = '';
   const title = document.createElement('div');
   title.className = 'title';
@@ -429,6 +436,7 @@ function showProfilePopup(id, uname, position){
 
 function hideProfilePopup(){
   profilePopup.classList.remove('active');
+  justOpenedProfile = false;
 }
 
 function followGps(id){


### PR DESCRIPTION
## Summary
- Add fullscreen overlay at startup with watch and play choices
- Selecting Play shares location and hides overlay, while Watch flies to Null Island

## Testing
- `php -l Applications/Chat/Web/index.php`
- `composer install --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b7f4bb4764832ea7d5ded528c27374