### PR TITLE
Show moon and realtime earth shadow in Cesium

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -221,8 +221,16 @@ Cesium.Ion.defaultAccessToken = CESIUM_ION_TOKEN;
 
 const viewer = new Cesium.Viewer('cesiumContainer', {
     geocoder:false, homeButton:true, baseLayerPicker:false, timeline:false, animation:false,
-    sceneModePicker:false, navigationHelpButton:false
+    sceneModePicker:false, navigationHelpButton:false, shouldAnimate:true
   });
+
+viewer.scene.moon.show = true;
+viewer.scene.sun.show = true;
+viewer.scene.globe.enableLighting = true;
+viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
+viewer.clock.multiplier = 1;
+viewer.clock.currentTime = Cesium.JulianDate.now();
+viewer.clock.shouldAnimate = true;
   
 const locationEntities = {};
 const statusColors = {


### PR DESCRIPTION
## Summary
- enable Cesium moon and sun
- show earth's shadow with realtime clock

## Testing
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8cd66a1f8832eae11fa90217e5ec0