### PR TITLE
Fix WebRTC negotiation by properly ordering peer IDs

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -606,7 +606,9 @@ function createPeer(id){
   const pc = new RTCPeerConnection({iceServers: ICE_SERVERS});
 
   // Propriétés pour la négociation parfaite
-  pc._isPolite = Number(client_id) < Number(id);
+  const selfIdNum = parseInt(client_id, 16);
+  const peerIdNum = parseInt(id, 16);
+  pc._isPolite = selfIdNum < peerIdNum;
   pc._makingOffer = false;
   pc._ignoreOffer = false;
 


### PR DESCRIPTION
## Summary
- ensure WebRTC peers determine polite side by parsing hex IDs with `parseInt`

## Testing
- `composer validate`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8d901f93c832e9c5edfa7831bb84d