### PR TITLE
Limit location visibility to current room

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -887,6 +887,12 @@ function loginRoom(roomId){
   // reset UI utilisateurs (évite l'affichage d'une ancienne liste avant le "welcome")
   clients = {};
   renderUsers();
+  // reset localisation des anciens salons
+  Object.keys(locationEntities).forEach(id => {
+    viewer.entities.remove(locationEntities[id]);
+    delete locationEntities[id];
+  });
+  Object.keys(locationShared).forEach(id => delete locationShared[id]);
   ws.send(JSON.stringify({type:'login', client_name:name, room_id:roomId, status, ua: navigator.userAgent, client_uuid: client_id}));
 }
 


### PR DESCRIPTION
## Summary
- Restrict location broadcasts to the user's current chat room
- Track room ID with each stored location and clear markers when switching rooms

## Testing
- `php -l Applications/Chat/Events.php`
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba5355c630832ea7302e6c58b7e012