### PR TITLE
feat: add moon flight with Cesium imagery

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -224,7 +224,7 @@ const viewer = new Cesium.Viewer('cesiumContainer', {
     sceneModePicker:false, navigationHelpButton:false, shouldAnimate:true
   });
 
-viewer.scene.moon.show = true;
+viewer.scene.moon.show = false;
 Cesium.IonResource.fromAssetId(3954).then(function(resource){
   viewer.scene.moon.textureUrl = resource;
 });
@@ -370,6 +370,8 @@ viewBtn.onclick = () => {
 };
 toolbar.appendChild(viewBtn);
 function flyToEarth(){
+  viewer.scene.globe.show = true;
+  viewer.scene.moon.show = false;
   viewer.camera.flyTo({
     destination: Cesium.Cartesian3.fromDegrees(0, 0, 30000000),
     duration: 5
@@ -377,6 +379,8 @@ function flyToEarth(){
 }
 
 function flyToMoon(){
+  viewer.scene.globe.show = false;
+  viewer.scene.moon.show = true;
   const moon = viewer.scene.moon;
   const now = Cesium.JulianDate.now();
   const moonEci = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -381,7 +381,7 @@ function flyToMoon(){
     new Cesium.Cartesian3()
   );
   const direction = Cesium.Cartesian3.normalize(moonPos, new Cesium.Cartesian3());
-  const range = moon.boundingSphere.radius * 4;
+  const range = moon.ellipsoid.maximumRadius * 4;
   const destination = Cesium.Cartesian3.add(
     moonPos,
     Cesium.Cartesian3.multiplyByScalar(direction, range, new Cesium.Cartesian3()),

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -376,12 +376,15 @@ function flyToEarth(){
 
 function flyToMoon(){
   const moon = viewer.scene.moon;
-  const moonPos = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
-    Cesium.JulianDate.now(),
+  const now = Cesium.JulianDate.now();
+  const moonEci = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
+    now,
     new Cesium.Cartesian3()
   );
+  const icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(now);
+  const moonPos = Cesium.Matrix3.multiplyByVector(icrfToFixed, moonEci, new Cesium.Cartesian3());
   const direction = Cesium.Cartesian3.normalize(moonPos, new Cesium.Cartesian3());
-  const range = moon.ellipsoid.maximumRadius * 4;
+  const range = moon.ellipsoid.maximumRadius * 1.2;
   const destination = Cesium.Cartesian3.add(
     moonPos,
     Cesium.Cartesian3.multiplyByScalar(direction, range, new Cesium.Cartesian3()),

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -225,6 +225,7 @@ const viewer = new Cesium.Viewer('cesiumContainer', {
   });
 
 viewer.scene.moon.show = true;
+viewer.scene.moon.textureUrl = Cesium.IonResource.fromAssetId(3954);
 viewer.scene.sun.show = true;
 viewer.scene.globe.enableLighting = true;
 viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
@@ -375,7 +376,10 @@ function flyToEarth(){
 
 function flyToMoon(){
   const moon = viewer.scene.moon;
-  const moonPos = moon.position;
+  const moonPos = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
+    Cesium.JulianDate.now(),
+    new Cesium.Cartesian3()
+  );
   const direction = Cesium.Cartesian3.normalize(moonPos, new Cesium.Cartesian3());
   const range = moon.boundingSphere.radius * 4;
   const destination = Cesium.Cartesian3.add(

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -386,10 +386,13 @@ function flyToMoon(){
   const icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(now);
   const moonPos = Cesium.Matrix3.multiplyByVector(icrfToFixed, moonEci, new Cesium.Cartesian3());
   const direction = Cesium.Cartesian3.normalize(moonPos, new Cesium.Cartesian3());
-  const range = moon.ellipsoid.maximumRadius * 1.2;
   const destination = Cesium.Cartesian3.add(
     moonPos,
-    Cesium.Cartesian3.multiplyByScalar(direction, range, new Cesium.Cartesian3()),
+    Cesium.Cartesian3.multiplyByScalar(
+      direction,
+      moon.ellipsoid.maximumRadius + 1000,
+      new Cesium.Cartesian3()
+    ),
     new Cesium.Cartesian3()
   );
   const toMoon = Cesium.Cartesian3.normalize(

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -367,6 +367,49 @@ viewBtn.onclick = () => {
 };
 toolbar.appendChild(viewBtn);
 
+const earthGlobe = viewer.scene.globe;
+const earthImageryProvider = viewer.imageryLayers.get(0).imageryProvider;
+let moonGlobe = null;
+let moonImageryProvider = null;
+
+function flyToEarth(){
+  viewer.scene.globe = earthGlobe;
+  viewer.imageryLayers.removeAll();
+  viewer.imageryLayers.addImageryProvider(earthImageryProvider);
+  viewer.scene.skyAtmosphere.show = true;
+  viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,30000000)});
+}
+
+function flyToMoon(){
+  if (!moonGlobe) {
+    moonGlobe = new Cesium.Globe(Cesium.Ellipsoid.MOON);
+  }
+  viewer.scene.globe = moonGlobe;
+  viewer.scene.skyAtmosphere.show = false;
+  viewer.imageryLayers.removeAll();
+  const loadProvider = moonImageryProvider
+    ? Promise.resolve(moonImageryProvider)
+    : Cesium.IonImageryProvider.fromAssetId(3954).then(p=> (moonImageryProvider = p));
+  loadProvider.then(provider => {
+    viewer.imageryLayers.addImageryProvider(provider);
+    viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,1737400*4)});
+  });
+}
+
+const earthBtn = document.createElement('button');
+earthBtn.className = 'cesium-button cesium-toolbar-button';
+earthBtn.textContent = '🌍';
+earthBtn.title = 'Voler vers la Terre';
+earthBtn.onclick = flyToEarth;
+toolbar.appendChild(earthBtn);
+
+const moonBtn = document.createElement('button');
+moonBtn.className = 'cesium-button cesium-toolbar-button';
+moonBtn.textContent = '🌑';
+moonBtn.title = 'Voler vers la Lune';
+moonBtn.onclick = flyToMoon;
+toolbar.appendChild(moonBtn);
+
 const startOverlay = document.getElementById('startOverlay');
 document.getElementById('watchBtn').onclick = () => {
   showToast('Vous allez être posé sur Null Island (0 latitude, 0 longitude)');

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -366,33 +366,31 @@ viewBtn.onclick = () => {
   updateViewBtn();
 };
 toolbar.appendChild(viewBtn);
-
-const earthGlobe = viewer.scene.globe;
-const earthImageryProvider = viewer.imageryLayers.get(0).imageryProvider;
-let moonGlobe = null;
-let moonImageryProvider = null;
-
 function flyToEarth(){
-  viewer.scene.globe = earthGlobe;
-  viewer.imageryLayers.removeAll();
-  viewer.imageryLayers.addImageryProvider(earthImageryProvider);
-  viewer.scene.skyAtmosphere.show = true;
-  viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,30000000)});
+  viewer.camera.flyTo({
+    destination: Cesium.Cartesian3.fromDegrees(0, 0, 30000000),
+    duration: 5
+  });
 }
 
 function flyToMoon(){
-  if (!moonGlobe) {
-    moonGlobe = new Cesium.Globe(Cesium.Ellipsoid.MOON);
-  }
-  viewer.scene.globe = moonGlobe;
-  viewer.scene.skyAtmosphere.show = false;
-  viewer.imageryLayers.removeAll();
-  const loadProvider = moonImageryProvider
-    ? Promise.resolve(moonImageryProvider)
-    : Cesium.IonImageryProvider.fromAssetId(3954).then(p=> (moonImageryProvider = p));
-  loadProvider.then(provider => {
-    viewer.imageryLayers.addImageryProvider(provider);
-    viewer.camera.flyTo({destination: Cesium.Cartesian3.fromDegrees(0,0,1737400*4)});
+  const moon = viewer.scene.moon;
+  const moonPos = moon.position;
+  const direction = Cesium.Cartesian3.normalize(moonPos, new Cesium.Cartesian3());
+  const range = moon.boundingSphere.radius * 4;
+  const destination = Cesium.Cartesian3.add(
+    moonPos,
+    Cesium.Cartesian3.multiplyByScalar(direction, range, new Cesium.Cartesian3()),
+    new Cesium.Cartesian3()
+  );
+  const toMoon = Cesium.Cartesian3.normalize(
+    Cesium.Cartesian3.subtract(moonPos, destination, new Cesium.Cartesian3()),
+    new Cesium.Cartesian3()
+  );
+  viewer.camera.flyTo({
+    destination,
+    orientation: { direction: toMoon, up: Cesium.Cartesian3.UNIT_Z },
+    duration: 5
   });
 }
 

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -225,7 +225,9 @@ const viewer = new Cesium.Viewer('cesiumContainer', {
   });
 
 viewer.scene.moon.show = true;
-viewer.scene.moon.textureUrl = Cesium.IonResource.fromAssetId(3954);
+Cesium.IonResource.fromAssetId(3954).then(function(resource){
+  viewer.scene.moon.textureUrl = resource;
+});
 viewer.scene.sun.show = true;
 viewer.scene.globe.enableLighting = true;
 viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;


### PR DESCRIPTION
## Summary
- add toolbar buttons to fly between Earth and Moon
- load lunar imagery from Cesium Ion and switch globe/atmosphere

## Testing
- `php -l Applications/Chat/Web/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba9f2d7bd0832eba55071722f74e90