### PR TITLE
feat: add basic SEO tags and sitemap

### DIFF
--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -7,8 +7,25 @@ include __DIR__ . '/../../../config.php';
   <meta charset="UTF-8" />
   <title>⚡ Chat Futuriste ⚡</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Chat futuriste pour se connecter et converser en temps réel sur une carte interactive." />
+  <link rel="canonical" href="https://couckan.com/" />
+  <meta property="og:title" content="Chat Futuriste" />
+  <meta property="og:description" content="Rejoignez Couckan pour discuter en temps réel sur une carte interactive mondiale." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://couckan.com/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Chat Futuriste" />
+  <meta name="twitter:description" content="Rejoignez Couckan pour discuter en temps réel sur une carte interactive mondiale." />
   <link href="https://cesium.com/downloads/cesiumjs/releases/1.111/Build/Cesium/Widgets/widgets.css" rel="stylesheet" />
   <script src="https://cesium.com/downloads/cesiumjs/releases/1.111/Build/Cesium/Cesium.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Couckan Chat",
+    "url": "https://couckan.com/"
+  }
+  </script>
   <style>
     :root{
       --bg:#0f172a; --panel:#1e293b; --muted:#334155; --muted-2:#475569;

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://couckan.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://couckan.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- enhance SEO metadata with description, social tags, and structured data
- add robots.txt and sitemap.xml for search engine indexing

## Testing
- `php -l Applications/Chat/Web/index.php`
- `xmllint --noout sitemap.xml`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68c0a0e33f90832ebb4f3a5db4d4eb74