### PR TITLE
feat(chat): preserve DM history across reconnections

### DIFF
--- a/Applications/Chat/Events.php
+++ b/Applications/Chat/Events.php
@@ -281,6 +281,26 @@ class Events
             }
 
             /**
+             * Historique des messages privés avec un utilisateur.
+             */
+            case 'dm_history': {
+                $to = $data['to_client_id'] ?? null;
+                if(!$to) return;
+                $uuid = $_SESSION['client_uuid'] ?? $client_id;
+                $room_key = 'dm:' . min($uuid, $to) . ':' . max($uuid, $to);
+                $history = ChatDb::getMessages($room_key, 50);
+                foreach ($history as &$m) {
+                    $m['dm'] = true;
+                }
+                unset($m);
+                Gateway::sendToClient($client_id, json_encode([
+                    'type'     => 'history',
+                    'messages' => $history,
+                ]));
+                return;
+            }
+
+            /**
              * Message :
              *  - DM : envoie à l'autre ET au sender (une seule fois chacun)
              *  - Room : broadcast à la room courante


### PR DESCRIPTION
## Summary
- ensure server returns previous direct messages on demand
- request DM history when opening a conversation
- persist open DM tabs in localStorage so guests reconnect into the same window
- show DM partner's online status and refresh tabs on status changes

## Testing
- `php -l Applications/Chat/Web/index.php`
- `php -l Applications/Chat/Events.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0e6054400832e98ba056cd7f48ab3