### PR TITLE
feat: support offline announcement messaging

### DIFF
--- a/Applications/Api/start_api.php
+++ b/Applications/Api/start_api.php
@@ -49,7 +49,9 @@ $api->onMessage = function ($connection, $request) {
             $lat = isset($data['latitude']) ? (float)$data['latitude'] : null;
             $lng = isset($data['longitude']) ? (float)$data['longitude'] : null;
             $range = null;
-            if (isset($data['range'])) {
+            if (isset($data['range_km'])) {
+                $range = (float)$data['range_km'];
+            } elseif (isset($data['range'])) {
                 $range = (float)$data['range'];
             } elseif (isset($data['radius'])) {
                 $range = (float)$data['radius'];

--- a/Applications/Api/start_api.php
+++ b/Applications/Api/start_api.php
@@ -209,6 +209,26 @@ $api->onMessage = function ($connection, $request) {
         return;
     }
 
+    if (preg_match('#^/announce/(\d+)/summary$#', $path, $m)) {
+        $announcementId = (int)$m[1];
+        if ($method === 'OPTIONS') {
+            $connection->send(new Response(204, $headers, ''));
+            return;
+        }
+        if ($method === 'GET') {
+            $since = $request->get('since');
+            $messages = ChatDb::getAnnouncementSummary($announcementId, $since);
+            if ($request->get('mark') === '1') {
+                ChatDb::markAnnouncementNotified($announcementId);
+            }
+            $body = json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        $connection->send(new Response(405, $headers, json_encode(['error' => 'Method Not Allowed'])));
+        return;
+    }
+
     $body = json_encode($_config, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     $connection->send(new Response(200, $headers, $body));
 };

--- a/Applications/Api/start_api.php
+++ b/Applications/Api/start_api.php
@@ -7,6 +7,7 @@ use Workerman\Protocols\Http\Response;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../Chat/ChatDb.php';
 
 
 
@@ -28,11 +29,152 @@ $api->onMessage = function ($connection, $request) {
     $headers = [
         'Content-Type'              => 'application/json; charset=utf-8',
         'Cache-Control'             => 'no-cache',
-        // CORS (optionnel)
         'Access-Control-Allow-Origin'  => '*',
         'Access-Control-Allow-Headers' => 'Content-Type, Authorization',
         'Access-Control-Allow-Methods' => 'GET, POST, OPTIONS',
     ];
+
+    $path = $request->path();
+    $method = strtoupper($request->method());
+
+    if ($path === '/announce') {
+        if ($method === 'OPTIONS') {
+            $connection->send(new Response(204, $headers, ''));
+            return;
+        }
+        if ($method === 'POST') {
+            $data = json_decode($request->rawBody(), true) ?: [];
+            $title = trim($data['title'] ?? '');
+            $description = trim($data['description'] ?? '');
+            $lat = isset($data['latitude']) ? (float)$data['latitude'] : null;
+            $lng = isset($data['longitude']) ? (float)$data['longitude'] : null;
+            $range = null;
+            if (isset($data['range'])) {
+                $range = (float)$data['range'];
+            } elseif (isset($data['radius'])) {
+                $range = (float)$data['radius'];
+            }
+            $contact = isset($data['contact']) ? (string)$data['contact'] : null;
+            $area = isset($data['area']) ? (string)$data['area'] : null;
+            $landmarks = isset($data['landmarks']) ? (string)$data['landmarks'] : null;
+            $allowed_keywords = null;
+            if (isset($data['allowed_keywords'])) {
+                if (is_array($data['allowed_keywords'])) {
+                    $allowed_keywords = implode(',', $data['allowed_keywords']);
+                } else {
+                    $allowed_keywords = (string)$data['allowed_keywords'];
+                }
+            }
+            if ($title === '' || $description === '' || ($lat === null && $area === null)) {
+                $body = json_encode(['error' => 'Invalid payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $connection->send(new Response(400, $headers, $body));
+                return;
+            }
+            $is_offline = isset($data['is_offline']) ? (bool)$data['is_offline'] : true;
+            $auto_reply = isset($data['auto_reply']) ? (string)$data['auto_reply'] : null;
+            $notify_interval = isset($data['notify_interval']) ? (string)$data['notify_interval'] : null;
+            $visible_until = isset($data['visible_until']) ? (string)$data['visible_until'] : null;
+            $is_anonymous = isset($data['is_anonymous']) ? (bool)$data['is_anonymous'] : false;
+            $id = ChatDb::addAnnouncement($title, $description, $lat, $lng, $range, $contact, $area, $landmarks, $allowed_keywords, $is_offline, $auto_reply, $notify_interval, $visible_until, $is_anonymous);
+            $body = json_encode(['status' => 'ok', 'id' => $id], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        if ($method === 'GET') {
+            $announces = ChatDb::getAnnouncements();
+            foreach ($announces as &$a) {
+                if (!empty($a['is_anonymous'])) {
+                    unset($a['contact']);
+                }
+            }
+            $body = json_encode($announces, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        $connection->send(new Response(405, $headers, json_encode(['error' => 'Method Not Allowed'])));
+        return;
+    }
+
+    if (preg_match('#^/announce/(\d+)/messages$#', $path, $m)) {
+        $announcementId = (int)$m[1];
+        if ($method === 'OPTIONS') {
+            $connection->send(new Response(204, $headers, ''));
+            return;
+        }
+        if ($method === 'POST') {
+            $data = json_decode($request->rawBody(), true) ?: [];
+            $content = trim($data['content'] ?? '');
+            if ($content === '') {
+                $body = json_encode(['error' => 'Invalid payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $connection->send(new Response(400, $headers, $body));
+                return;
+            }
+            $from_contact = isset($data['from_contact']) ? (string)$data['from_contact'] : null;
+            $announcement = ChatDb::getAnnouncement($announcementId);
+            if ($announcement && !empty($announcement['allowed_keywords'])) {
+                $allowed = array_map('trim', explode(',', $announcement['allowed_keywords']));
+                $allowed = array_filter($allowed, 'strlen');
+                $found = false;
+                foreach ($allowed as $kw) {
+                    if (stripos($content, $kw) !== false) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if (!$found) {
+                    $body = json_encode(['error' => 'Message not allowed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                    $connection->send(new Response(403, $headers, $body));
+                    return;
+                }
+            }
+            ChatDb::addAnnouncementMessage($announcementId, $from_contact, $content);
+            $resp = ['status' => 'ok'];
+            if ($announcement && $announcement['auto_reply']) {
+                $resp['auto_reply'] = $announcement['auto_reply'];
+            }
+            $body = json_encode($resp, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        if ($method === 'GET') {
+            $messages = ChatDb::getAnnouncementMessages($announcementId);
+            $body = json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        $connection->send(new Response(405, $headers, json_encode(['error' => 'Method Not Allowed'])));
+        return;
+    }
+
+    if (preg_match('#^/announce/(\d+)/schedule$#', $path, $m)) {
+        $announcementId = (int)$m[1];
+        if ($method === 'OPTIONS') {
+            $connection->send(new Response(204, $headers, ''));
+            return;
+        }
+        if ($method === 'POST') {
+            $data = json_decode($request->rawBody(), true) ?: [];
+            $content = trim($data['content'] ?? '');
+            $send_at = trim($data['send_at'] ?? '');
+            if ($content === '' || $send_at === '') {
+                $body = json_encode(['error' => 'Invalid payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $connection->send(new Response(400, $headers, $body));
+                return;
+            }
+            ChatDb::scheduleAnnouncementMessage($announcementId, $content, $send_at);
+            $body = json_encode(['status' => 'ok'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        if ($method === 'GET') {
+            $messages = ChatDb::getScheduledAnnouncementMessages($announcementId);
+            $body = json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $connection->send(new Response(200, $headers, $body));
+            return;
+        }
+        $connection->send(new Response(405, $headers, json_encode(['error' => 'Method Not Allowed'])));
+        return;
+    }
 
     $body = json_encode($_config, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     $connection->send(new Response(200, $headers, $body));

--- a/Applications/Chat/ChatDb.php
+++ b/Applications/Chat/ChatDb.php
@@ -46,11 +46,6 @@ class ChatDb
             last_notified TEXT,
             created_at TEXT
         )');
-        try {
-            self::$db->exec('ALTER TABLE announcements ADD COLUMN last_notified TEXT');
-        } catch (\PDOException $e) {
-            // column already exists
-        }
         self::$db->exec('CREATE TABLE IF NOT EXISTS announcement_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             announcement_id INTEGER,

--- a/Applications/Chat/ChatDb.php
+++ b/Applications/Chat/ChatDb.php
@@ -27,6 +27,38 @@ class ChatDb
             ip TEXT,
             time TEXT
         )');
+        self::$db->exec('CREATE TABLE IF NOT EXISTS announcements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            description TEXT,
+            latitude REAL,
+            longitude REAL,
+            range_km REAL,
+            contact TEXT,
+            area TEXT,
+            landmarks TEXT,
+            allowed_keywords TEXT,
+            is_offline INTEGER DEFAULT 1,
+            auto_reply TEXT,
+            notify_interval TEXT,
+            visible_until TEXT,
+            is_anonymous INTEGER DEFAULT 0,
+            created_at TEXT
+        )');
+        self::$db->exec('CREATE TABLE IF NOT EXISTS announcement_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            announcement_id INTEGER,
+            from_contact TEXT,
+            content TEXT,
+            created_at TEXT
+        )');
+        self::$db->exec('CREATE TABLE IF NOT EXISTS announcement_scheduled_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            announcement_id INTEGER,
+            content TEXT,
+            send_at TEXT,
+            created_at TEXT
+        )');
     }
 
     public static function logMessage(string $room, string $from_id, string $from_name, string $to_id, string $content): void
@@ -50,5 +82,80 @@ class ChatDb
         self::init();
         $stmt = self::$db->prepare('INSERT INTO requests (path, user_agent, ip, time) VALUES (?,?,?,?)');
         $stmt->execute([$path, $user_agent, $ip, date('Y-m-d H:i:s')]);
+    }
+
+    public static function addAnnouncement(string $title, string $description, ?float $latitude, ?float $longitude, ?float $range,
+        ?string $contact = null, ?string $area = null, ?string $landmarks = null, ?string $allowed_keywords = null,
+        bool $is_offline = true, ?string $auto_reply = null, ?string $notify_interval = null,
+        ?string $visible_until = null, bool $is_anonymous = false): int
+    {
+        self::init();
+        $stmt = self::$db->prepare('INSERT INTO announcements (title, description, latitude, longitude, range_km, contact, area, landmarks, allowed_keywords, is_offline, auto_reply, notify_interval, visible_until, is_anonymous, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+        $stmt->execute([
+            $title,
+            $description,
+            $latitude,
+            $longitude,
+            $range,
+            $contact,
+            $area,
+            $landmarks,
+            $allowed_keywords,
+            $is_offline ? 1 : 0,
+            $auto_reply,
+            $notify_interval,
+            $visible_until,
+            $is_anonymous ? 1 : 0,
+            date('Y-m-d H:i:s')
+        ]);
+        return (int) self::$db->lastInsertId();
+    }
+
+    public static function addAnnouncementMessage(int $announcement_id, ?string $from_contact, string $content): int
+    {
+        self::init();
+        $stmt = self::$db->prepare('INSERT INTO announcement_messages (announcement_id, from_contact, content, created_at) VALUES (?,?,?,?)');
+        $stmt->execute([$announcement_id, $from_contact, $content, date('Y-m-d H:i:s')]);
+        return (int) self::$db->lastInsertId();
+    }
+
+    public static function getAnnouncementMessages(int $announcement_id): array
+    {
+        self::init();
+        $stmt = self::$db->prepare('SELECT id, from_contact, content, created_at FROM announcement_messages WHERE announcement_id = ? ORDER BY id DESC');
+        $stmt->execute([$announcement_id]);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public static function scheduleAnnouncementMessage(int $announcement_id, string $content, string $send_at): int
+    {
+        self::init();
+        $stmt = self::$db->prepare('INSERT INTO announcement_scheduled_messages (announcement_id, content, send_at, created_at) VALUES (?,?,?,?)');
+        $stmt->execute([$announcement_id, $content, $send_at, date('Y-m-d H:i:s')]);
+        return (int) self::$db->lastInsertId();
+    }
+
+    public static function getScheduledAnnouncementMessages(int $announcement_id): array
+    {
+        self::init();
+        $stmt = self::$db->prepare('SELECT id, content, send_at, created_at FROM announcement_scheduled_messages WHERE announcement_id = ? ORDER BY id DESC');
+        $stmt->execute([$announcement_id]);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public static function getAnnouncement(int $id): ?array
+    {
+        self::init();
+        $stmt = self::$db->prepare('SELECT id, title, description, latitude, longitude, range_km, contact, area, landmarks, allowed_keywords, is_offline, auto_reply, notify_interval, visible_until, is_anonymous, created_at FROM announcements WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    public static function getAnnouncements(): array
+    {
+        self::init();
+        $stmt = self::$db->query('SELECT id, title, description, latitude, longitude, range_km, contact, area, landmarks, allowed_keywords, is_offline, notify_interval, visible_until, is_anonymous, created_at FROM announcements ORDER BY id DESC');
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
     }
 }

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -267,6 +267,8 @@ viewer.clock.currentTime = Cesium.JulianDate.now();
 viewer.clock.shouldAnimate = true;
   
 const locationEntities = {};
+const announcementEntities = {};
+const API_BASE = `${location.protocol}//${location.hostname}:8002`;
 const statusColors = {
   online: Cesium.Color.fromCssColorString('#22c55e'),
   busy: Cesium.Color.fromCssColorString('#f97316'),
@@ -1659,6 +1661,44 @@ function onSubmit(){
   ta.value = '';
 }
 
+async function loadAnnouncements(){
+  try{
+    const res = await fetch(`${API_BASE}/announce`);
+    if(!res.ok) return;
+    const list = await res.json();
+    list.forEach(a=>{
+      if(a.latitude !== null && a.longitude !== null){
+        const id = `announce_${a.id}`;
+        announcementEntities[id] = viewer.entities.add({
+          id,
+          position: Cesium.Cartesian3.fromDegrees(a.longitude, a.latitude),
+          point: { pixelSize: 8, color: Cesium.Color.YELLOW },
+          name: a.title || 'Annonce',
+          description:
+            (a.description?`<p>${a.description}</p>`:'')+
+            (a.area?`<p>Zone: ${a.area}</p>`:'')+
+            (a.landmarks?`<p>Repères: ${a.landmarks}</p>`:'')+
+            (a.contact?`<p>Contact: ${a.contact}</p>`:'')
+        });
+        if(a.range_km){
+          viewer.entities.add({
+            position: Cesium.Cartesian3.fromDegrees(a.longitude, a.latitude),
+            ellipse:{
+              semiMajorAxis:a.range_km*1000,
+              semiMinorAxis:a.range_km*1000,
+              material:Cesium.Color.YELLOW.withAlpha(0.2),
+              outline:true,
+              outlineColor:Cesium.Color.YELLOW
+            }
+          });
+        }
+      }
+    });
+  }catch(e){
+    console.error('announces', e);
+  }
+}
+
 /* Enter -> envoyer ; Ctrl+Enter -> retour ligne */
 document.getElementById('input').addEventListener('keydown', (e)=>{
   if (e.key === 'Enter' && !e.ctrlKey) { e.preventDefault(); onSubmit(); }
@@ -1684,6 +1724,7 @@ function clearBlink(key){
 }
 
 /* Boot UI */
+loadAnnouncements();
 connect();
 renderTabs();
 renderMessages();

--- a/Applications/Chat/Web/index.php
+++ b/Applications/Chat/Web/index.php
@@ -1678,7 +1678,9 @@ async function loadAnnouncements(){
             (a.description?`<p>${a.description}</p>`:'')+
             (a.area?`<p>Zone: ${a.area}</p>`:'')+
             (a.landmarks?`<p>Repères: ${a.landmarks}</p>`:'')+
-            (a.contact?`<p>Contact: ${a.contact}</p>`:'')
+            (a.is_offline?`<p>Annonce hors ligne – réponses différées.</p>`:'')+
+            (a.contact?`<p>Contact: ${a.contact}</p>`:'')+
+            (a.average_rating?`<p>Note: ${a.average_rating.toFixed(1)} (${a.rating_count})</p>`:'')
         });
         if(a.range_km){
           viewer.entities.add({


### PR DESCRIPTION
## Summary
- allow announcements without precise coordinates and rename radius to range_km
- accept range or area descriptions for a broader, privacy-friendly location
- add keyword filtering, anonymous contact hiding and scheduled follow-up messages

## Testing
- `php -l Applications/Chat/ChatDb.php`
- `php -l Applications/Api/start_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68c24b70c8d4832ebcb310bb50762f12